### PR TITLE
fix: attempting to avoid collisions on the host field

### DIFF
--- a/.codegen/datadog_formatter.go.jinja2
+++ b/.codegen/datadog_formatter.go.jinja2
@@ -46,7 +46,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}

--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -39,7 +39,7 @@ var (
 		"environment",
 		"service",
 		"container",
-		"host",
+		"host_name",
 	}
 
 	optionalTags = []string{

--- a/cmd/mini-collector/main.go
+++ b/cmd/mini-collector/main.go
@@ -43,7 +43,7 @@ func main() {
 		"environment": environmentName,
 		"service":     serviceName,
 		"container":   containerId,
-		"host":        containerId[0:12],
+		"host_name":   containerId[0:12],
 	}
 
 	appName, ok := os.LookupEnv("MINI_COLLECTOR_APP_NAME")

--- a/writer/datadog/api.proto.datadog_formatter.go
+++ b/writer/datadog/api.proto.datadog_formatter.go
@@ -41,7 +41,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -61,7 +61,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -81,7 +81,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -101,7 +101,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -121,7 +121,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -141,7 +141,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -161,7 +161,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -181,7 +181,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -201,7 +201,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -221,7 +221,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -241,7 +241,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -261,7 +261,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}
@@ -281,7 +281,7 @@ func formatBatch(batch batch.Batch) datadogPayload {
 				Tags: tags,
 			}
 
-			host, ok = entry.Tags["host"]
+			host, ok = entry.Tags["host_name"]
 			if ok {
 				series.Host = host
 			}

--- a/writer/datadog/datadog_test.go
+++ b/writer/datadog/datadog_test.go
@@ -23,7 +23,7 @@ func TestFormatBatchAddsHostIfPresent(t *testing.T) {
 	entry := batch.Entry{
 		PublishRequest: &api.PublishRequest{},
 		Tags: map[string]string{
-			"host": "my-host",
+			"host_name": "my-host",
 		},
 	}
 

--- a/writer/datadog/types.go
+++ b/writer/datadog/types.go
@@ -13,8 +13,12 @@ type datadogSeries struct {
 	Metric string         `json:"metric"`
 	Points []datadogPoint `json:"points"`
 	Type   string         `json:"type"`
-	Host   string         `json:"host"`
-	Tags   []string       `json:"tags"`
+	// Host directly collides with the http spec, due to the need
+	// for GRPC to submit both :authority and host, we will lose
+	// this header. In some places we will use .host_name, which
+	// this is also an alias for.
+	Host string   `json:"host"`
+	Tags []string `json:"tags"`
 }
 
 type datadogPayload struct {


### PR DESCRIPTION
I think this is happening because of this: https://github.com/grpc/grpc-go/blob/da1a5eb25d2a3be62c5419c7004f9c0d669ba8bf/internal/transport/http2_server.go#L451 line

I think the metadata field for `host` collided with other fields. I had a hack in another PR (we should discard that), because I tried to generate a new metadata context as the grpc context is mostly some places it doesn't matter (there's only 2-3 places it really matters - where it enters and where it may be used to reply)

## Proof

Running:

<img width="462" alt="image" src="https://user-images.githubusercontent.com/2961973/234740268-eaf34bd8-d83e-4dd0-9847-4888d1b86484.png">

<img width="936" alt="image" src="https://user-images.githubusercontent.com/2961973/234740197-ecc5ec96-720a-4f8b-9812-d903606e5aee.png">


Datadog proof:

disk

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/2961973/234740758-acb04c9f-4940-4801-9d85-7a577ab08ac0.png">

cpu+mem:

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/2961973/234740828-2d30df58-80cc-4ef0-a21a-9ef3b18f7ace.png">
